### PR TITLE
Change the display of h tags in Markdown

### DIFF
--- a/src/layouts/BlogDetail.astro
+++ b/src/layouts/BlogDetail.astro
@@ -21,8 +21,7 @@ const author = await getCollection('member')
       @apply mb-4 list-inside list-disc pl-4;
     }
     .markdown-body h1,
-    h2,
-    h3 {
+    h2, h3, h4, h5, h6 {
       @apply mb-4 flex;
     }
     .markdown-body h1,

--- a/src/remark/remark-custom-alert.ts
+++ b/src/remark/remark-custom-alert.ts
@@ -130,6 +130,7 @@ const remarkCustomAlerts: Plugin<RemarkGitHubAlertsOptions[], Root> = (
 
         // 改行後のテキストを保持し、<br> タグを挿入
         const textLines = parameters.slice(1);
+        // @ts-ignore
         firstParagraph.children = textLines.flatMap((line, index) =>
           index === 0
             ? [{ type: 'text', value: line.trim() }]
@@ -143,6 +144,7 @@ const remarkCustomAlerts: Plugin<RemarkGitHubAlertsOptions[], Root> = (
           .slice(match[0].length)
           .split('\n')
           .map((line) => line.trim());
+        // @ts-ignore
         firstParagraph.children = textLines.flatMap((line, index) =>
           index === 0
             ? [{ type: 'text', value: line }]


### PR DESCRIPTION
h4, h5, h6 の#の前に改行が入るのを修正しました