### PR TITLE
Bug fix header/footer alignment on blog

### DIFF
--- a/src/layouts/BlogDetail.astro
+++ b/src/layouts/BlogDetail.astro
@@ -69,6 +69,20 @@ const author = await getCollection('member')
       @apply bg-slate-300;
     }
 
+    .frame pre code {
+      @apply block min-w-0;
+    }
+
+    .expressive-code *:not(path) .code{
+      width: auto !important;
+      min-width: 0 !important;
+    }
+
+    .copy {
+      width: 2.5rem !important;
+    }
+
+
     .markdown-body pre code {
       @apply bg-inherit;
     }


### PR DESCRIPTION
Codeが挿入されているブログでヘッダーとフッターの表示がズレるバグを修正しました。

画面サイズが340px以下になるとまた同じ問題が残ってるけど、そんなちっちゃい画面で見ないことを信じて...