### PR TITLE
Feature/markdown editor improvements

### DIFF
--- a/src/pages/tools/blog/editor/index.astro
+++ b/src/pages/tools/blog/editor/index.astro
@@ -309,9 +309,6 @@ const COMMON_TAGS = [
     // 定数定義
     const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
 
-    // DOM要素をキャッシュ
-    let cachedPreviewElement: HTMLElement | null = null;
-
     // カーソル位置にテキストを挿入する関数
     function insertTextAtCursor(
       textarea: HTMLTextAreaElement,
@@ -335,88 +332,33 @@ const COMMON_TAGS = [
       textarea.dispatchEvent(new Event('input', { bubbles: true }));
     }
 
-    // ローカル画像パスを解決する関数
-    function resolveLocalImages(imageManager: ImageManager): void {
+    // コードブロックのスタイルを動的に適用する関数
+    function applyCodeBlockStyles() {
       const previewElement = document.getElementById('preview');
       if (!previewElement) {
         return;
       }
 
-      const images = previewElement.querySelectorAll('img');
-
-      images.forEach((img) => {
-        const src = img.getAttribute('src');
-
-        if (src && src.startsWith('./')) {
-          const imageName = src.substring(2); // './' を除去
-          const imageData = imageManager.getImageDataByName(imageName);
-
-          if (imageData) {
-            img.setAttribute('src', imageData);
-            img.setAttribute('data-original-src', src);
-          } else {
-            // 画像が見つからない場合の処理
-            img.setAttribute('alt', `画像が見つかりません: ${imageName}`);
-            img.style.backgroundColor = '#f3f4f6';
-            img.style.border = '2px dashed #d1d5db';
-            img.style.padding = '20px';
-            img.style.display = 'inline-block';
-            img.style.minWidth = '200px';
-            img.style.minHeight = '100px';
-          }
-        }
+      const codeBlocks = previewElement.querySelectorAll('pre code');
+      codeBlocks.forEach((codeBlock) => {
+        const element = codeBlock as HTMLElement;
+        element.style.backgroundColor = '#000000';
+        element.style.color = '#ffffff';
+        element.style.borderRadius = '0.375rem';
+        element.style.display = 'block';
+        element.style.overflowX = 'auto';
+        element.style.lineHeight = '1.5';
       });
-    }
 
-    // プレビュー更新時にローカル画像を解決する関数
-    function updatePreviewWithLocalImages(
-      markdownText: string,
-      imageManager: ImageManager,
-      updatePreviewFn: (text: string) => void
-    ): void {
-      // 通常のプレビュー更新
-      updatePreviewFn(markdownText);
-
-      // MutationObserverを使用してDOM更新を監視
-      const previewElement = document.getElementById('preview');
-      if (previewElement) {
-        const observer = new MutationObserver(() => {
-          resolveLocalImages(imageManager);
-          observer.disconnect();
-        });
-        observer.observe(previewElement, { childList: true, subtree: true });
-      }
-    }
-
-    // コードブロックのスタイルを動的に適用する関数
-    function applyCodeBlockStyles() {
-      // プレビュー要素をキャッシュして再利用
-      if (!cachedPreviewElement) {
-        cachedPreviewElement = document.getElementById('preview');
-      }
-
-      if (cachedPreviewElement) {
-        const codeBlocks = cachedPreviewElement.querySelectorAll('pre code');
-        codeBlocks.forEach((codeBlock) => {
-          const element = codeBlock as HTMLElement;
-          element.style.backgroundColor = '#000000';
-          element.style.color = '#ffffff';
-          element.style.borderRadius = '0.375rem';
-          element.style.display = 'block';
-          element.style.overflowX = 'auto';
-          element.style.lineHeight = '1.5';
-        });
-
-        const preElements = cachedPreviewElement.querySelectorAll('pre');
-        preElements.forEach((pre) => {
-          const element = pre as HTMLElement;
-          element.style.backgroundColor = '#000000';
-          element.style.borderRadius = '0.375rem';
-          element.style.padding = '1rem';
-          element.style.margin = '1rem 0';
-          element.style.overflowX = 'auto';
-        });
-      }
+      const preElements = previewElement.querySelectorAll('pre');
+      preElements.forEach((pre) => {
+        const element = pre as HTMLElement;
+        element.style.backgroundColor = '#000000';
+        element.style.borderRadius = '0.375rem';
+        element.style.padding = '1rem';
+        element.style.margin = '1rem 0';
+        element.style.overflowX = 'auto';
+      });
     }
 
     // エディターの初期化
@@ -449,11 +391,6 @@ const COMMON_TAGS = [
         return processedHtml;
       };
 
-      // EventHandlerManager用のラッパー関数（戻り値がstringである必要がある）
-      const updatePreviewForEventHandler = (markdown: string): string => {
-        return enhancedUpdatePreview(markdown);
-      };
-
       // uiManagerのupdatePreviewを置き換え（初期化前に実行）
       uiManager.updatePreview = enhancedUpdatePreview;
 
@@ -462,7 +399,7 @@ const COMMON_TAGS = [
         uiManager,
         tagManager,
         localStorageManager,
-        updatePreviewForEventHandler
+        enhancedUpdatePreview
       );
 
       // 画像挿入ボタンのイベントハンドラー

--- a/src/pages/tools/blog/editor/index.astro
+++ b/src/pages/tools/blog/editor/index.astro
@@ -10,7 +10,7 @@ const COMMON_TAGS = [
   'monthly',
   'tips',
   'info',
-  'news'
+  'news',
 ] as const;
 ---
 
@@ -436,8 +436,7 @@ const COMMON_TAGS = [
               imageButton.disabled = true;
 
               // 画像を処理してローカルストレージに保存
-              const { imageName, imageKey } =
-                await imageManager.saveImage(file);
+              const { imageName } = await imageManager.saveImage(file);
 
               // Markdown記法をカーソル位置に挿入
               const markdownText = `![${imageName}](./${imageName} '${imageName}')`;

--- a/src/remark/editor-initializer.ts
+++ b/src/remark/editor-initializer.ts
@@ -57,7 +57,6 @@ export function initializeMarkdownParser(): void {
       breaks: true,
       gfm: true,
       pedantic: false,
-      sanitize: false, // 画像のsrc属性を保持するため
     });
   } catch (error) {
     console.error('Marked初期化エラー:', error);

--- a/src/remark/markdown-editor.ts
+++ b/src/remark/markdown-editor.ts
@@ -801,14 +801,27 @@ function parse(content: string): ParsedMarkdown {
 }
 
 /**
+ * Markdownから最初の画像パスを抽出する
+ * @param markdown - Markdownテキスト
+ * @returns 最初の画像パス、またはnull
+ */
+function extractFirstImagePath(markdown: string): string | null {
+  const imageRegex = /!\[([^\]]*)\]\(([^\s']+)(?:\s+'([^']+)')?\)/g;
+  const match = imageRegex.exec(markdown);
+  return match ? match[2] : null;
+}
+
+/**
  * フロントマターデータを文字列に変換する
  * @param data - エディターデータ
  * @returns フロントマター文字列
  */
 function generate(data: EditorData): string {
   let frontmatter = '---\n';
+
+  // 基本フィールドを順序通りに追加
   for (const [key, value] of Object.entries(data)) {
-    if (key === 'markdown' || key === 'savedAt') continue;
+    if (key === 'markdown' || key === 'savedAt' || key === 'cover') continue;
 
     if (key === 'tags' && Array.isArray(value)) {
       frontmatter += `tag: [${value.map((tag) => `'${tag}'`).join(', ')}]\n`;
@@ -816,6 +829,13 @@ function generate(data: EditorData): string {
       frontmatter += `${key}: "${value}"\n`;
     }
   }
+
+  // 画像が存在する場合、coverフィールドをauthor_name_mainの前に追加
+  const firstImagePath = extractFirstImagePath(data.markdown);
+  if (firstImagePath) {
+    frontmatter += `cover: "${firstImagePath}"\n`;
+  }
+
   frontmatter += '---\n';
   frontmatter += data.markdown || '';
   return frontmatter;

--- a/src/remark/markdown-editor.ts
+++ b/src/remark/markdown-editor.ts
@@ -442,27 +442,8 @@ export function updatePreviewWithImages(
   markdown: string,
   imageManager: ImageManager,
 ): string {
-  // 基本的なMarkdown変換を実行
+  // 基本的なMarkdown変換を実行（画像タグも含めて処理）
   let html = updatePreview(markdown);
-
-  // もし画像タグが含まれていない場合、手動で変換
-  if (!html.includes('<img') && markdown.includes('![')) {
-    // 画像のMarkdown構文を手動でHTMLに変換
-    const imageRegex = /!\[([^\]]*)\]\(([^\s']+)(?:\s+'([^']+)')?\)/g;
-    const imageHtml = markdown.replace(imageRegex, (match, alt, src, title) => {
-      return `<img src="${src}" alt="${alt}" title="${title || ''}">`;
-    });
-
-    // 他のMarkdown構文も簡易変換
-    html = imageHtml
-      .replace(/### (.+)/g, '<h3>$1</h3>')
-      .replace(/## (.+)/g, '<h2>$1</h2>')
-      .replace(/# (.+)/g, '<h1>$1</h1>')
-      .replace(/\n\n/g, '</p><p>')
-      .replace(/\n/g, '<br>');
-
-    html = `<p>${html}</p>`;
-  }
 
   // ローカルストレージの画像データでパスを置換
   return processImagePathsInHtml(html, imageManager);

--- a/src/remark/markdown-editor.ts
+++ b/src/remark/markdown-editor.ts
@@ -340,10 +340,10 @@ function processImagePathsInHtml(
   const doc = parser.parseFromString(html, 'text/html');
   const images = doc.querySelectorAll('img');
 
-  images.forEach((img) => {
+  for (const img of images) {
     const src = img.getAttribute('src');
 
-    if (src && src.startsWith('./')) {
+    if (src?.startsWith('./')) {
       const imageName = src.substring(2); // './' を除去
       const imageData = imageManager.getImageDataByName(imageName);
 
@@ -360,7 +360,7 @@ function processImagePathsInHtml(
         img.style.minHeight = '100px';
       }
     }
-  });
+  }
 
   return doc.body.innerHTML;
 }
@@ -443,7 +443,7 @@ export function updatePreviewWithImages(
   imageManager: ImageManager,
 ): string {
   // 基本的なMarkdown変換を実行（画像タグも含めて処理）
-  let html = updatePreview(markdown);
+  const html = updatePreview(markdown);
 
   // ローカルストレージの画像データでパスを置換
   return processImagePathsInHtml(html, imageManager);
@@ -921,7 +921,9 @@ export class ImageManager {
         localStorage.setItem(imageKey, dataUrl);
       } catch (e) {
         if (e instanceof DOMException && e.name === 'QuotaExceededError') {
-          throw new Error('ストレージ容量が不足しています。不要な画像を削除してください。');
+          throw new Error(
+            'ストレージ容量が不足しています。不要な画像を削除してください。',
+          );
         }
         throw e;
       }
@@ -957,7 +959,7 @@ export class ImageManager {
     const images: Array<{ key: string; name: string }> = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
-      if (key && key.startsWith('blog-editor-image-')) {
+      if (key?.startsWith('blog-editor-image-')) {
         const name = key.replace('blog-editor-image-', '');
         images.push({ key, name });
       }

--- a/src/remark/marked-instance.ts
+++ b/src/remark/marked-instance.ts
@@ -2,7 +2,7 @@
  * markedインスタンスを取得するためのユーティリティ
  */
 
-import { marked } from 'marked';
+import { type MarkedOptions, marked } from 'marked';
 
 /**
  * 同期版のmarkedインスタンスを提供する
@@ -10,7 +10,7 @@ import { marked } from 'marked';
  */
 interface MarkedSync {
   parse: (markdown: string) => string;
-  setOptions: (options: any) => void;
+  setOptions: (options: MarkedOptions) => void;
 }
 
 /**
@@ -30,7 +30,7 @@ export function getMarkedInstance(): MarkedSync {
         'Marked returned a Promise, but synchronous parsing is required',
       );
     },
-    setOptions: (options: any) => {
+    setOptions: (options: MarkedOptions) => {
       marked.setOptions(options);
     },
   };

--- a/src/remark/sanitizer.ts
+++ b/src/remark/sanitizer.ts
@@ -31,6 +31,7 @@ const ALLOWED_ALERT_TAGS = [
   'blockquote',
   'a',
   'br',
+  'img',
 ];
 
 const ALLOWED_ALERT_ATTRIBUTES = [
@@ -45,6 +46,9 @@ const ALLOWED_ALERT_ATTRIBUTES = [
   'href',
   'target',
   'rel',
+  'src',
+  'alt',
+  'title',
 ];
 
 /**
@@ -77,9 +81,10 @@ const ALLOWED_BASIC_TAGS = [
   'tr',
   'th',
   'td',
+  'img',
 ];
 
-const ALLOWED_BASIC_ATTRIBUTES = ['href', 'target', 'rel', 'class'];
+const ALLOWED_BASIC_ATTRIBUTES = ['href', 'target', 'rel', 'class', 'src', 'alt', 'title'];
 
 /**
  * カスタムアラートを含むHTMLをサニタイズする

--- a/src/remark/sanitizer.ts
+++ b/src/remark/sanitizer.ts
@@ -84,7 +84,15 @@ const ALLOWED_BASIC_TAGS = [
   'img',
 ];
 
-const ALLOWED_BASIC_ATTRIBUTES = ['href', 'target', 'rel', 'class', 'src', 'alt', 'title'];
+const ALLOWED_BASIC_ATTRIBUTES = [
+  'href',
+  'target',
+  'rel',
+  'class',
+  'src',
+  'alt',
+  'title',
+];
 
 /**
  * カスタムアラートを含むHTMLをサニタイズする

--- a/src/remark/ui-manager.ts
+++ b/src/remark/ui-manager.ts
@@ -220,6 +220,7 @@ export class UIManager {
       date: this.elements.dateInput?.value || '',
       lead: this.elements.leadInput?.value || '',
       tags: tagManager.getTags(),
+      author_name_main: '著者名を入力(不要な場合には行全体を削除)',
       markdown: this.elements.markdownEditor?.value || '',
       savedAt: new Date().toISOString(),
     };
@@ -481,7 +482,7 @@ export class EventHandlerManager {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${data.title || 'blog'}.md`;
+    a.download = 'blog.md';
     a.click();
     URL.revokeObjectURL(url);
   }
@@ -554,7 +555,7 @@ export class EventHandlerManager {
     const zip = new JSZip();
 
     // MarkdownファイルをZIPに追加
-    zip.file(`${data.title || 'blog'}.md`, frontmatter);
+    zip.file(`blog.md`, frontmatter);
 
     // 画像ファイルをZIPに追加
     for (const image of images) {

--- a/src/remark/ui-manager.ts
+++ b/src/remark/ui-manager.ts
@@ -477,7 +477,7 @@ export class EventHandlerManager {
   /**
    * Markdownファイルのみをダウンロードする（フォールバック用）
    */
-  private downloadMarkdownOnly(data: any, frontmatter: string): void {
+  private downloadMarkdownOnly(_data: EditorData, frontmatter: string): void {
     const blob = new Blob([frontmatter], { type: 'text/markdown' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -497,9 +497,9 @@ export class EventHandlerManager {
 
     // Markdown内の画像構文を抽出する正規表現
     const imageRegex = /!\[([^\]]*)\]\(([^\s']+)(?:\s+'([^']+)')?\)/g;
-    let match;
+    let match: RegExpExecArray | null = imageRegex.exec(markdown);
 
-    while ((match = imageRegex.exec(markdown)) !== null) {
+    while (match !== null) {
       const imagePath = match[2]; // 画像のパス部分
 
       // ローカル画像パス（./image_name）の場合のみ処理
@@ -513,40 +513,18 @@ export class EventHandlerManager {
           usedImages.push({ name: imageName, data: imageData });
         }
       }
+
+      match = imageRegex.exec(markdown);
     }
 
     return usedImages;
   }
 
   /**
-   * ローカルストレージから保存された画像のリストを取得（デバッグ用）
-   */
-  private getAllStoredImages(): Array<{ name: string; data: string }> {
-    const images: Array<{ name: string; data: string }> = [];
-
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (
-        key &&
-        key.startsWith('blog-editor-image-') &&
-        key !== 'blog-editor-image-counter'
-      ) {
-        const name = key.replace('blog-editor-image-', '');
-        const data = localStorage.getItem(key);
-        if (data) {
-          images.push({ name, data });
-        }
-      }
-    }
-
-    return images;
-  }
-
-  /**
    * ZIPファイルを作成してダウンロードする
    */
   private async createAndDownloadZip(
-    data: any,
+    data: EditorData,
     frontmatter: string,
     images: Array<{ name: string; data: string }>,
   ): Promise<void> {
@@ -555,7 +533,7 @@ export class EventHandlerManager {
     const zip = new JSZip();
 
     // MarkdownファイルをZIPに追加
-    zip.file(`blog.md`, frontmatter);
+    zip.file('blog.md', frontmatter);
 
     // 画像ファイルをZIPに追加
     for (const image of images) {

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -10,6 +10,8 @@ export interface EditorData {
   date: string;
   lead: string;
   tags: string[];
+  author_name_main: string;
+  cover?: string;
   markdown: string;
   savedAt: string;
 }


### PR DESCRIPTION

## 概要

このプルリクエストでは、ブログ用 Markdown エディタに以下の変更・改善を加えました。また、`pnpm check` スクリプトのバグも修正しています。

---

### 🆕 新機能

- **著者名（author_name_main）フィールド** と **サムネイル URL（cover）フィールド** を投稿メタデータとして保存されるように保存ロジックを拡張

---

### 🔧 リファクタ & 改善

1. **画像アップロード＆サニタイズ強化**  
   - アップロード→HTML挿入のワークフローを簡素化  
   - `sanitizer.ts` で `<img>` の `src` / `alt` / `title` 属性をホワイトリストに追加  
2. **コード整理**  
   - `markdown-editor.ts`／`ui-manager.ts` 内の未使用関数を削除  
   - 共通初期化処理を `editor-initializer.ts` に抽出  
3. **設定微調整**  
   - `marked-instance.ts` のレンダリング設定を統一

---

### 🐛 バグ修正

- **pnpm check**  
  - Lint と型チェックが正しく走るようにスクリプトを修正

---