### PR TITLE
ブログ著者の参照方法の修正

### DIFF
--- a/src/layouts/BlogDetail.astro
+++ b/src/layouts/BlogDetail.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import ToC from '@components/ToC.astro';
 import Layout from '@layouts/Layout.astro';
 import MarkdownStyles from '../remark/MarkdownStyles.astro';
+import { matchNames } from '../utils/nameNormalizer';
 
 const { data, headings } = Astro.props;
 const author_name = data.author_name_main;
@@ -11,7 +12,9 @@ import AuthorCard from '@components/AuthorCard.astro';
 
 const author = await getCollection('member')
   .then((authors) =>
-    authors.find((author) => author.data.name.main === author_name),
+    authors.find(
+      (author) => author_name && matchNames(author.data.name.main, author_name),
+    ),
   )
   .catch(() => undefined);
 ---

--- a/src/pages/member/[...slug].astro
+++ b/src/pages/member/[...slug].astro
@@ -4,6 +4,7 @@ import { Icon } from 'astro-icon/components';
 
 import { getCollection } from 'astro:content';
 import BlogPostListItem from '@components/ui/BlogPostListItem.astro';
+import { matchNames } from '../../utils/nameNormalizer';
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('member');
@@ -19,7 +20,11 @@ const { Content } = await entry.render();
 
 const blog_posts = await getCollection('blog');
 const wrote_posts = blog_posts
-  .filter((post) => post.data.author_name_main === entry.data.name.main)
+  .filter(
+    (post) =>
+      post.data.author_name_main &&
+      matchNames(post.data.author_name_main, entry.data.name.main),
+  )
   .sort((a, b) => Date.parse(b.data.date) - Date.parse(a.data.date));
 ---
 

--- a/src/utils/nameNormalizer.ts
+++ b/src/utils/nameNormalizer.ts
@@ -1,0 +1,15 @@
+/**
+ * 名前の正規化を行う関数
+ * 半角スペースと全角スペースを削除して比較用の文字列を生成
+ */
+export function normalizeName(name: string): string {
+  return name.replace(/[\s\u3000]/g, '');
+}
+
+/**
+ * 名前のマッチングを行う関数
+ * 両方の名前を正規化してから比較
+ */
+export function matchNames(name1: string, name2: string): boolean {
+  return normalizeName(name1) === normalizeName(name2);
+}


### PR DESCRIPTION
## What
- ブログの著者の参照方法を変更
    - 苗字と名前の間のスペースが半角でも全角でも一致と判定されるように修正

## Why
- スペースの種類が違うと該当なしとなるのは不便なため