### PR TITLE
使いにくいHIの館: 方向クイズ・大クイズ・導入スライドの改修

### DIFF
--- a/src/pages/unusable_HI_Mansion/_style.css
+++ b/src/pages/unusable_HI_Mansion/_style.css
@@ -34,6 +34,7 @@ body {
 .imageText {
   font-family: "Helvetica Neue", Helvetica, Arial, "Roboto", "Noto Sans",
     sans-serif;
+  font-weight: bold;
 }
 
 ::selection {
@@ -67,6 +68,40 @@ button:hover {
   color: #f33;
   background: linear-gradient(to bottom, #700, #400);
   box-shadow: 0 0 2vw rgba(230, 0, 0, 0.8);
+}
+
+/* YES=緑(赤ボタンの緑版) / NO=既定の赤ボタンのまま。
+   id に紐づくため、左右の配置が入れ替わっても色は不変 */
+#yes {
+  color: #3a3;
+  background: linear-gradient(to bottom, #004d00, #003300);
+  box-shadow: 0 0 1vw rgba(0, 200, 0, 0.8);
+}
+
+#yes:hover {
+  color: #3f3;
+  background: linear-gradient(to bottom, #070, #040);
+  box-shadow: 0 0 2vw rgba(0, 200, 0, 0.8);
+}
+
+/* YES/NO を急かすシークバー(画面上部・5秒でゼロになる。時間切れでも遷移はしない) */
+.seek-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: max(24px, 2.2vw);
+  background: rgba(40, 0, 0, 0.55);
+  z-index: 20;
+  overflow: hidden;
+}
+
+.seek-fill {
+  width: 100%;
+  height: 100%;
+  transform-origin: left center;
+  background: linear-gradient(to bottom, #f33, #900);
+  box-shadow: 0 0 1.2vw rgba(230, 0, 0, 0.9);
 }
 
 @keyframes blink {
@@ -115,15 +150,80 @@ button:hover {
 }
 
 .textButton {
-  width: max(80px, 8.3vw); /* ボタンの幅 */
-  height: max(80px, 8.3vw); /* ボタンの高さ */
+  width: max(70px, 7vw); /* ボタンの幅 */
+  height: max(70px, 7vw); /* ボタンの高さ */
   border: 0.1px solid white; /* 白い枠 */
   background-color: black; /* 黒い背景 */
   color: white; /* 文字色 */
-  font-size: max(40px, 4vw); /* フォントサイズ */
+  font-size: max(34px, 3.4vw); /* フォントサイズ */
   font-weight: bold;
   text-align: center; /* テキストを中央揃え */
   cursor: pointer;
-  line-height: max(80px, 8.3vw); /* テキストを垂直方向に中央揃え */
+  line-height: max(70px, 7vw); /* テキストを垂直方向に中央揃え */
   outline: none; /* ボタンにフォーカス時の枠を消す */
+}
+
+/* 上下左右→色の対応を示す縁のバー(上=赤 / 下=青 / 左=オレンジ / 右=緑) */
+.dir-bar {
+  position: absolute;
+  z-index: 6;
+}
+.dir-bar.top {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: max(14px, 1.4vw);
+  background-color: #cc3333;
+}
+.dir-bar.bottom {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: max(14px, 1.4vw);
+  background-color: #3366cc;
+}
+.dir-bar.left {
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: max(14px, 1.4vw);
+  background-color: #e67e22;
+}
+.dir-bar.right {
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: max(14px, 1.4vw);
+  background-color: #2e9c46;
+}
+
+/* 問題ページ右側の凡例(すべての矢印に色が対応していることを示す) */
+.dir-legend {
+  position: absolute;
+  bottom: max(50px, 5vw);
+  right: max(40px, 4vw);
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: max(6px, 0.6vw);
+  z-index: 7;
+}
+.dir-legend .legend-card {
+  position: relative;
+  width: max(44px, 4.4vw);
+  height: max(44px, 4.4vw);
+  border-radius: max(6px, 0.6vw);
+}
+.dir-legend .legend-card img {
+  width: 100%;
+  height: 100%;
+  clip-path: inset(6%);
+}
+.dir-legend .legend-card span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: max(22px, 2.2vw);
+  font-weight: bold;
+  color: #000;
 }

--- a/src/pages/unusable_HI_Mansion/_style.css
+++ b/src/pages/unusable_HI_Mansion/_style.css
@@ -84,7 +84,7 @@ button:hover {
   box-shadow: 0 0 2vw rgba(0, 200, 0, 0.8);
 }
 
-/* YES/NO を急かすシークバー(画面上部・5秒でゼロになる。時間切れでも遷移はしない) */
+/* 残り時間を示すシークバー(画面下部)。各スライドで制限時間ぶんかけてゼロになる */
 .seek-bar {
   position: absolute;
   bottom: 0;
@@ -150,80 +150,15 @@ button:hover {
 }
 
 .textButton {
-  width: max(70px, 7vw); /* ボタンの幅 */
-  height: max(70px, 7vw); /* ボタンの高さ */
+  width: max(80px, 8.3vw); /* ボタンの幅 */
+  height: max(80px, 8.3vw); /* ボタンの高さ */
   border: 0.1px solid white; /* 白い枠 */
   background-color: black; /* 黒い背景 */
   color: white; /* 文字色 */
-  font-size: max(34px, 3.4vw); /* フォントサイズ */
+  font-size: max(40px, 4vw); /* フォントサイズ */
   font-weight: bold;
   text-align: center; /* テキストを中央揃え */
   cursor: pointer;
-  line-height: max(70px, 7vw); /* テキストを垂直方向に中央揃え */
+  line-height: max(80px, 8.3vw); /* テキストを垂直方向に中央揃え */
   outline: none; /* ボタンにフォーカス時の枠を消す */
-}
-
-/* 上下左右→色の対応を示す縁のバー(上=赤 / 下=青 / 左=オレンジ / 右=緑) */
-.dir-bar {
-  position: absolute;
-  z-index: 6;
-}
-.dir-bar.top {
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: max(14px, 1.4vw);
-  background-color: #cc3333;
-}
-.dir-bar.bottom {
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: max(14px, 1.4vw);
-  background-color: #3366cc;
-}
-.dir-bar.left {
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: max(14px, 1.4vw);
-  background-color: #e67e22;
-}
-.dir-bar.right {
-  top: 0;
-  right: 0;
-  height: 100%;
-  width: max(14px, 1.4vw);
-  background-color: #2e9c46;
-}
-
-/* 問題ページ右側の凡例(すべての矢印に色が対応していることを示す) */
-.dir-legend {
-  position: absolute;
-  bottom: max(50px, 5vw);
-  right: max(40px, 4vw);
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  gap: max(6px, 0.6vw);
-  z-index: 7;
-}
-.dir-legend .legend-card {
-  position: relative;
-  width: max(44px, 4.4vw);
-  height: max(44px, 4.4vw);
-  border-radius: max(6px, 0.6vw);
-}
-.dir-legend .legend-card img {
-  width: 100%;
-  height: 100%;
-  clip-path: inset(6%);
-}
-.dir-legend .legend-card span {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: max(22px, 2.2vw);
-  font-weight: bold;
-  color: #000;
 }

--- a/src/pages/unusable_HI_Mansion/slides/slide14.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide14.astro
@@ -7,12 +7,17 @@ import ghost from './Images/_ghost.png';
 
 <SlideLayout>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div class="textArea">
       <div
         class="text first"
         style="position: absolute; top: 20%; left: 40%; font-size: max(60px, 5vw);"
       >
-        <span class="white">「上っ！！」</span>
+        <span
+          class="white"
+          style="background-color: #cc3333; padding: 0.08em 0.3em; border-radius: 0.15em;"
+          >「上っ！！」</span
+        >
       </div>
     </div>
     <Image
@@ -47,8 +52,21 @@ import ghost from './Images/_ghost.png';
         }
 
         elementsInfo = shuffleArray(elementsInfo);
+        // この回の正解位置を記録(次の回で同じ位置に正解を出さないために使う)
+        localStorage.setItem(
+          'arrowLastCorrectPos',
+          String(elementsInfo.findIndex((e) => e.class === 'correct'))
+        );
 
         const container = document.getElementById('buttonContainer');
+
+        // 方向色: 上=赤 / 右=緑 / 下=青 / 左=オレンジ
+        const DIR_COLOR = {
+          '0': '#cc3333',
+          '90': '#2e9c46',
+          '180': '#3366cc',
+          '270': '#e67e22'
+        };
 
         elementsInfo.forEach((info) => {
           const div = document.createElement('div');
@@ -57,12 +75,17 @@ import ghost from './Images/_ghost.png';
           div.style.opacity = '1';
           div.style.display = 'inline-block';
           div.style.position = 'relative'; // 親要素に相対位置を設定
+          // 方向色をカード背景に
+          div.style.backgroundColor = DIR_COLOR[info.rotation];
+          div.style.padding = 'max(12px, 1.2vw)';
+          div.style.borderRadius = 'max(8px, 0.8vw)';
 
           const img = document.createElement('img');
           img.src = '/arrowButton.png';
           img.style.width = 'max(100px, 10vw)';
           img.style.zIndex = '1';
           img.style.transform = `rotate(${info.rotation}deg)`;
+          img.style.clipPath = 'inset(6%)'; // 矢印画像の外周の白枠を切り取る
 
           const span = document.createElement('span');
           span.classList.add('imageText');
@@ -81,6 +104,13 @@ import ghost from './Images/_ghost.png';
       }
 
       addElementsToContainer();
+
+      // 3秒の制限時間をシークバーで表示(残り時間が減っていく)
+      const seekFill = document.querySelector('.seek-fill');
+      seekFill.animate(
+        [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+        { duration: 3000, easing: 'linear', fill: 'forwards' }
+      );
 
       const correct = document.getElementsByClassName('correct')[0];
       const wrong = document.getElementsByClassName('wrong');

--- a/src/pages/unusable_HI_Mansion/slides/slide15.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide15.astro
@@ -7,12 +7,17 @@ import ghost from './Images/_ghost.png';
 
 <SlideLayout>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div class="textArea">
       <div
         class="text first"
         style="position: absolute; top: 20%; left: 40%; font-size: max(60px, 5vw);"
       >
-        <span class="white">「下っ！！」</span>
+        <span
+          class="white"
+          style="background-color: #3366cc; padding: 0.08em 0.3em; border-radius: 0.15em;"
+          >「下っ！！」</span
+        >
       </div>
     </div>
     <Image
@@ -46,9 +51,32 @@ import ghost from './Images/_ghost.png';
           return array;
         }
 
-        elementsInfo = shuffleArray(elementsInfo);
+        // 前回(1回目)の正解位置を避けてシャッフル(正解が同じ位置に連続しないように)
+        const prevPos = parseInt(
+          localStorage.getItem('arrowLastCorrectPos') ?? '-1',
+          10
+        );
+        do {
+          elementsInfo = shuffleArray(elementsInfo);
+        } while (
+          prevPos >= 0 &&
+          elementsInfo.findIndex((e) => e.class === 'correct') === prevPos
+        );
+        // この回の正解位置を記録(次の回で使う)
+        localStorage.setItem(
+          'arrowLastCorrectPos',
+          String(elementsInfo.findIndex((e) => e.class === 'correct'))
+        );
 
         const container = document.getElementById('buttonContainer');
+
+        // 方向色: 上=赤 / 右=緑 / 下=青 / 左=オレンジ
+        const DIR_COLOR = {
+          '0': '#cc3333',
+          '90': '#2e9c46',
+          '180': '#3366cc',
+          '270': '#e67e22'
+        };
 
         elementsInfo.forEach((info) => {
           const div = document.createElement('div');
@@ -57,12 +85,17 @@ import ghost from './Images/_ghost.png';
           div.style.opacity = '1';
           div.style.display = 'inline-block';
           div.style.position = 'relative'; // 親要素に相対位置を設定
+          // 方向色をカード背景に
+          div.style.backgroundColor = DIR_COLOR[info.rotation];
+          div.style.padding = 'max(12px, 1.2vw)';
+          div.style.borderRadius = 'max(8px, 0.8vw)';
 
           const img = document.createElement('img');
           img.src = '/arrowButton.png';
           img.style.width = 'max(100px, 10vw)';
           img.style.zIndex = '1';
           img.style.transform = `rotate(${info.rotation}deg)`;
+          img.style.clipPath = 'inset(6%)'; // 矢印画像の外周の白枠を切り取る
 
           const span = document.createElement('span');
           span.classList.add('imageText');
@@ -81,6 +114,13 @@ import ghost from './Images/_ghost.png';
       }
 
       addElementsToContainer();
+
+      // 3秒の制限時間をシークバーで表示(残り時間が減っていく)
+      const seekFill = document.querySelector('.seek-fill');
+      seekFill.animate(
+        [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+        { duration: 3000, easing: 'linear', fill: 'forwards' }
+      );
 
       const correct = document.getElementsByClassName('correct')[0];
       const wrong = document.getElementsByClassName('wrong');

--- a/src/pages/unusable_HI_Mansion/slides/slide16.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide16.astro
@@ -117,7 +117,7 @@ import ghost from './Images/_ghost.png';
           div.style.opacity = '1';
           div.style.display = 'inline-block';
           div.style.position = 'relative'; // 親要素に相対位置を設定
-          // 色は方向とずらしてある(ウソの色)
+          // 文字と色は固定ペア。ウソをつくのは矢印の向きだけ
           div.style.backgroundColor = info.color;
           div.style.padding = 'max(12px, 1.2vw)';
           div.style.borderRadius = 'max(8px, 0.8vw)';

--- a/src/pages/unusable_HI_Mansion/slides/slide16.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide16.astro
@@ -7,12 +7,17 @@ import ghost from './Images/_ghost.png';
 
 <SlideLayout>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div class="textArea">
       <div
         class="text first"
         style="position: absolute; top: 20%; left: 40%; font-size: max(60px, 5vw);"
       >
-        <span class="white">「左っ！！」</span>
+        <span
+          class="white"
+          style="background-color: #e67e22; padding: 0.08em 0.3em; border-radius: 0.15em;"
+          >「左っ！！」</span
+        >
       </div>
     </div>
     <Image
@@ -31,12 +36,13 @@ import ghost from './Images/_ghost.png';
   <script is:inline>
     window.addEventListener('DOMContentLoaded', () => {
       function addElementsToContainer() {
-        let elementsInfo = [
-          { class: 'correct', rotation: '270', text: '下' },
-          { class: 'incorrect', rotation: '90', text: '左' },
-          { class: 'wrong', rotation: '180', text: '上' },
-          { class: 'wrong', rotation: '0', text: '右' }
-        ];
+        // 方向色: 上=赤 / 右=緑 / 下=青 / 左=オレンジ
+        const DIR_COLOR = {
+          '0': '#cc3333',
+          '90': '#2e9c46',
+          '180': '#3366cc',
+          '270': '#e67e22'
+        };
 
         function shuffleArray(array) {
           for (let i = array.length - 1; i > 0; i--) {
@@ -46,7 +52,60 @@ import ghost from './Images/_ghost.png';
           return array;
         }
 
-        elementsInfo = shuffleArray(elementsInfo);
+        // 3問目は「矢印だけがウソ」: 文字と色は常にペア(上=赤/右=緑/下=青/左=オレンジ)
+        // のまま保持し、矢印の向きだけをシャッフルする。
+        // 正解=矢印が左(270)を指すカード。ひっかけ=文字が「左」(色オレンジ)だが矢印は左でないカード。
+        const cards = [
+          { text: '上', color: DIR_COLOR['0'], kanjiDir: '0' },
+          { text: '右', color: DIR_COLOR['90'], kanjiDir: '90' },
+          { text: '下', color: DIR_COLOR['180'], kanjiDir: '180' },
+          { text: '左', color: DIR_COLOR['270'], kanjiDir: '270' }
+        ];
+        // 「左」の文字は必ず右向き矢印(90)に固定して重ねる(上下より左右の取り違えを誘う)。
+        // 残り3枚(上/右/下)に残りの矢印{0,180,270}を割り当て、どのカードも
+        // 文字と同じ向きの矢印にならないようにする(矢印だけがウソ)。
+        const leftCard = cards.find((c) => c.text === '左');
+        leftCard.rotation = '90';
+        const otherCards = cards.filter((c) => c.text !== '左');
+        const otherRots = ['0', '180', '270'];
+        let assign;
+        do {
+          assign = shuffleArray(otherRots.slice());
+        } while (assign.some((r, i) => r === otherCards[i].kanjiDir));
+        otherCards.forEach((c, i) => {
+          c.rotation = assign[i];
+        });
+
+        cards.forEach((c) => {
+          if (c.rotation === '270') c.class = 'correct'; // 矢印が左=正解
+          else if (c.text === '左') c.class = 'incorrect'; // 文字「左」だが矢印は左でない=ひっかけ
+          else c.class = 'wrong';
+        });
+
+        // ひっかけ(incorrect=オレンジ)を2回目の正解位置に、正解はそれ以外の位置に置く
+        const prevPos = parseInt(
+          localStorage.getItem('arrowLastCorrectPos') ?? '-1',
+          10
+        );
+        const correctEl = cards.find((c) => c.class === 'correct');
+        const trapEl = cards.find((c) => c.class === 'incorrect');
+        const wrongEls = cards.filter((c) => c.class === 'wrong');
+
+        const trapPos =
+          prevPos >= 0 && prevPos <= 3
+            ? prevPos
+            : Math.floor(Math.random() * 4);
+        const remaining = shuffleArray(
+          [0, 1, 2, 3].filter((i) => i !== trapPos)
+        );
+
+        const arrangement = new Array(4);
+        arrangement[trapPos] = trapEl; // ひっかけ(オレンジ) = 前回の正解位置
+        arrangement[remaining[0]] = correctEl; // 正解(左) = 前回とは違う位置
+        arrangement[remaining[1]] = wrongEls[0];
+        arrangement[remaining[2]] = wrongEls[1];
+
+        const elementsInfo = arrangement;
         localStorage.setItem('shuffledArrows', JSON.stringify(elementsInfo));
 
         const container = document.getElementById('buttonContainer');
@@ -58,12 +117,17 @@ import ghost from './Images/_ghost.png';
           div.style.opacity = '1';
           div.style.display = 'inline-block';
           div.style.position = 'relative'; // 親要素に相対位置を設定
+          // 色は方向とずらしてある(ウソの色)
+          div.style.backgroundColor = info.color;
+          div.style.padding = 'max(12px, 1.2vw)';
+          div.style.borderRadius = 'max(8px, 0.8vw)';
 
           const img = document.createElement('img');
           img.src = '/arrowButton.png';
           img.style.width = 'max(100px, 10vw)';
           img.style.zIndex = '1';
           img.style.transform = `rotate(${info.rotation}deg)`;
+          img.style.clipPath = 'inset(6%)'; // 矢印画像の外周の白枠を切り取る
 
           const span = document.createElement('span');
           span.classList.add('imageText');
@@ -82,6 +146,13 @@ import ghost from './Images/_ghost.png';
       }
 
       addElementsToContainer();
+
+      // 3秒の制限時間をシークバーで表示(残り時間が減っていく)
+      const seekFill = document.querySelector('.seek-fill');
+      seekFill.animate(
+        [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+        { duration: 3000, easing: 'linear', fill: 'forwards' }
+      );
 
       const correct = document.getElementsByClassName('correct')[0];
       const wrong = document.getElementsByClassName('wrong');

--- a/src/pages/unusable_HI_Mansion/slides/slide2.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide2.astro
@@ -4,6 +4,7 @@ import SlideLayout from '@layouts/slide_layout.astro';
 
 <SlideLayout>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div
       class="textArea flex justify-center"
       style="margin-top: max(150px, 16vw); display: flex; flex-direction: column; align-items: center; font-size: max(30px, 3vw);"
@@ -11,7 +12,7 @@ import SlideLayout from '@layouts/slide_layout.astro';
       <div class="text first" style="opacity: 0;">
         あまりにも使いにくくて、イライラするかもしれません
       </div>
-      <div class="text second" style="margin-top: 10vw; opacity: 0;">
+      <div class="text second" style="margin-top: 5vw; opacity: 0;">
         それでも入りますか？
       </div>
     </div>
@@ -48,11 +49,25 @@ import SlideLayout from '@layouts/slide_layout.astro';
       const textFirst = document.querySelector('.first');
       const textSecond = document.querySelector('.second');
       const buttonArea = document.querySelector('.buttonArea');
+      const seekFill = document.querySelector('.seek-fill');
 
       // 画面の要素を時間差で登場させる
       setTimeout(() => {
         textFirst.style.transition = 'opacity 2s ease-in-out';
         textFirst.style.opacity = 1;
+        // 文字表示開始と同時にシークバーを5秒でゼロにする(急かし演出)
+        const seekAnim = seekFill.animate(
+          [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+          { duration: 5000, easing: 'linear', fill: 'forwards' }
+        );
+        // 時間切れ(バーがゼロ)で YES が倒れて下に消え、NO しか押せなくなる
+        seekAnim.finished.then(() => {
+          const yesButton = document.getElementById('yes');
+          yesButton.style.transition = 'top 2s, transform 1s';
+          yesButton.style.transform = 'translate(-50%, -50%) rotateX(90deg)';
+          yesButton.style.top = '110%';
+          yesButton.style.pointerEvents = 'none';
+        });
       }, 1000);
 
       setTimeout(() => {
@@ -63,7 +78,7 @@ import SlideLayout from '@layouts/slide_layout.astro';
       setTimeout(() => {
         buttonArea.style.transition = 'opacity 1s ease-in-out';
         buttonArea.style.opacity = 1;
-      }, 6000);
+      }, 2000);
 
       // ボタンが押されたら画面遷移
       const yesButton = document.getElementById('yes');

--- a/src/pages/unusable_HI_Mansion/slides/slide20.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide20.astro
@@ -38,7 +38,7 @@ import ghost_teacher from './Images/_ghost_teacher.png';
     <div
       class="flex justify-evenly"
       id="buttonContainer"
-      style="width: 100%; opacity: 0; position: absolute; top: 80%;"
+      style="width: 100%; opacity: 0; position: absolute; top: 80%; transform: translateY(-20%);"
     >
     </div>
   </div>
@@ -54,12 +54,17 @@ import ghost_teacher from './Images/_ghost_teacher.png';
           div.style.opacity = '1';
           div.style.display = 'inline-block';
           div.style.position = 'relative'; // 親要素に相対位置を設定
+          // 3問目(slide16)と同じ背景色・見た目に揃える
+          div.style.backgroundColor = info.color;
+          div.style.padding = 'max(12px, 1.2vw)';
+          div.style.borderRadius = 'max(8px, 0.8vw)';
 
           const img = document.createElement('img');
           img.src = '/arrowButton.png';
           img.style.width = 'max(100px, 10vw)';
           img.style.zIndex = '1';
           img.style.transform = `rotate(${info.rotation}deg)`;
+          img.style.clipPath = 'inset(6%)'; // 矢印画像の外周の白枠を切り取る
 
           const span = document.createElement('span');
           span.classList.add('imageText');

--- a/src/pages/unusable_HI_Mansion/slides/slide27.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide27.astro
@@ -25,6 +25,11 @@ import ghost from './Images/_ghost.png';
     .marquee-track .textButton {
       flex-shrink: 0;
       margin-right: 3.5vw;
+      /* 4行に収めるためカードを縮小(このクイズ内だけにスコープ) */
+      width: max(70px, 7vw);
+      height: max(70px, 7vw);
+      font-size: max(34px, 3.4vw);
+      line-height: max(70px, 7vw);
     }
   </style>
   <div class="slide-content">

--- a/src/pages/unusable_HI_Mansion/slides/slide27.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide27.astro
@@ -6,14 +6,36 @@ import ghost from './Images/_ghost.png';
 ---
 
 <SlideLayout>
+  <style is:inline>
+    /* 各行を回転寿司のように横スクロールさせる */
+    .marquee-row {
+      position: absolute;
+      left: 0;
+      width: 100%;
+      height: max(70px, 7vw);
+      overflow: hidden;
+    }
+    .marquee-track {
+      display: flex;
+      flex-wrap: nowrap;
+      width: max-content;
+      height: 100%;
+      will-change: transform;
+    }
+    .marquee-track .textButton {
+      flex-shrink: 0;
+      margin-right: 3.5vw;
+    }
+  </style>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div
       class="textArea"
       style="position: relative; top: 12%; left: 35%; transform: translate(0%, 0%);"
     >
       <div
         class="text white"
-        style="position: absolute; display: inline-block; font-size: max(60px, 5vw); opacity: 1;"
+        style="position: absolute; display: inline-block; font-size: max(60px, 5vw); opacity: 1; z-index: 3;"
       >
         「大」！！
       </div>
@@ -22,115 +44,149 @@ import ghost from './Images/_ghost.png';
       src={ghost}
       alt="ghost"
       class="ghost"
-      style="width: max(180px, 16vw); transform: translate(-50%, -50%); opacity: 1; position: absolute; top: 20%; left: 25%;"
+      style="width: max(180px, 16vw); transform: translate(-50%, -50%); opacity: 1; position: absolute; top: 20%; left: 25%; z-index: 2;"
     />
     <div id="container"></div>
   </div>
   <script is:inline>
-    function createTextButton(text, index, className, color) {
+    // 各行の縦位置・流れる向き・速度(px/秒)。slide29(種明かし)と揃える
+    const ROWS_META = [
+      { top: '33%', dir: 'left', speed: 110 },
+      { top: '48%', dir: 'right', speed: 95 },
+      { top: '63%', dir: 'left', speed: 130 },
+      { top: '78%', dir: 'right', speed: 105 }
+    ];
+    // 1行あたりの枚数(合計52、うち「大」は1枚だけ)
+    const ROW_SIZES = [13, 13, 13, 13];
+
+    const WRONG_POOL = [
+      { text: '太', class: 'wrong', color: 'blue' },
+      { text: '犬', class: 'wrong', color: 'green' },
+      { text: '人', class: 'wrong', color: 'purple' },
+      { text: '木', class: 'wrong', color: 'brown' }
+    ];
+
+    function buildRows() {
+      const total = ROW_SIZES.reduce((a, b) => a + b, 0);
+      const cards = [];
+      for (let i = 0; i < total; i++) {
+        const w = WRONG_POOL[Math.floor(Math.random() * WRONG_POOL.length)];
+        cards.push({ text: w.text, class: w.class, color: w.color });
+      }
+      // 「大」を1枚だけランダムな位置に仕込む
+      const correctIndex = Math.floor(Math.random() * total);
+      cards[correctIndex] = { text: '大', class: 'correct', color: 'orange' };
+      // 行ごとに分割
+      const rows = [];
+      let offset = 0;
+      for (const size of ROW_SIZES) {
+        rows.push(cards.slice(offset, offset + size));
+        offset += size;
+      }
+      return rows;
+    }
+
+    function createCard(card) {
       const div = document.createElement('div');
-      div.textContent = text;
-      div.classList.add('textButton', className, color);
-      div.style.position = 'absolute';
-      div.style.top = getTop(index);
-      div.style.left = getLeft(index);
+      div.textContent = card.text;
+      div.classList.add('textButton', card.class, card.color);
       return div;
     }
 
-    function getTop(index) {
-      if (index < 7) {
-        return '40%';
-      }
-      if (index < 14) {
-        return '60%';
-      }
-      if (index < 21) {
-        return '80%';
-      }
-      return 0;
-    }
+    function renderRows(container, rows) {
+      rows.forEach((rowData, i) => {
+        const meta = ROWS_META[i];
+        const row = document.createElement('div');
+        row.className = 'marquee-row';
+        row.style.top = meta.top;
 
-    function getLeft(index) {
-      return `${(index % 7) * 12 + 10}%`;
+        const track = document.createElement('div');
+        track.className = 'marquee-track';
+
+        // シームレスループのため同じ内容を2つ並べる
+        rowData.concat(rowData).forEach((card) => {
+          track.appendChild(createCard(card));
+        });
+
+        row.appendChild(track);
+        container.appendChild(row);
+
+        // レイアウト確定後に「1周分の実測幅」でループさせる(隙間ゼロ)
+        const first = track.children[0];
+        const second = track.children[rowData.length];
+        const dist = second.offsetLeft - first.offsetLeft; // 1周分の幅
+        const dur = (dist / meta.speed) * 1000;
+
+        // 「大」を含む行は、読み込み直後に「大」を進行方向の「入ってくる側」の
+        // 端の外へ隠す。t=0から進むとすぐ画面に現れ、5秒以内に必ず見える
+        let delay = 0;
+        const daiIndex = rowData.findIndex((c) => c.class === 'correct');
+        if (daiIndex !== -1) {
+          const W = row.clientWidth;
+          const daiOffset =
+            track.children[daiIndex].offsetLeft - first.offsetLeft;
+          // 左へ流れる行は右端の外、右へ流れる行は左端の外に隠す
+          const cardW = track.children[daiIndex].getBoundingClientRect().width;
+          const enterOffset = W * (0.02 + Math.random() * 0.12);
+          const x0 =
+            meta.dir === 'left' ? W + enterOffset : -cardW - enterOffset;
+          const desired =
+            ((((x0 - daiOffset) % dist) + dist) % dist) - dist; // [-dist, 0)
+          const ct =
+            meta.dir === 'left'
+              ? (-desired / dist) * dur
+              : dur * (1 + desired / dist);
+          delay = -ct;
+        }
+
+        const from = meta.dir === 'left' ? 0 : -dist;
+        const to = meta.dir === 'left' ? -dist : 0;
+        track.animate(
+          [
+            { transform: 'translateX(' + from + 'px)' },
+            { transform: 'translateX(' + to + 'px)' }
+          ],
+          {
+            duration: dur,
+            iterations: Infinity,
+            easing: 'linear',
+            delay: delay
+          }
+        );
+      });
     }
 
     window.addEventListener('DOMContentLoaded', function () {
-      let textButtons = [
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '太', class: 'wrong', color: 'blue' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '犬', class: 'wrong', color: 'green' },
-        { text: '人', class: 'wrong', color: 'orange' },
-        { text: '人', class: 'wrong', color: 'orange' },
-        { text: '人', class: 'wrong', color: 'orange' },
-        { text: '木', class: 'wrong', color: 'brown' },
-        { text: '木', class: 'wrong', color: 'brown' },
-        { text: '木', class: 'wrong', color: 'brown' },
-        { text: '木', class: 'wrong', color: 'brown' },
-        { text: '大', class: 'correct', color: 'black' }
-      ];
-
       const container = document.getElementById('container');
+      const rows = buildRows();
+      // slide29(種明かし)で同じ配置を再現するため保存
+      localStorage.setItem('shuffledButtons', JSON.stringify(rows));
 
-      function shuffleArray(array) {
-        for (let i = array.length - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1));
-          [array[i], array[j]] = [array[j], array[i]];
-        }
-        return array;
-      }
+      renderRows(container, rows);
 
-      textButtons = shuffleArray(textButtons);
-      localStorage.setItem('shuffledButtons', JSON.stringify(textButtons));
+      // 5秒の制限時間をシークバーで表示(残り時間が減っていく)
+      const seekFill = document.querySelector('.seek-fill');
+      seekFill.animate(
+        [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+        { duration: 5000, easing: 'linear', fill: 'forwards' }
+      );
 
-      textButtons.forEach((button, index) => {
-        const { text, class: className, color: color } = button;
-        const element = createTextButton(text, index, className, color);
-        container.appendChild(element);
-      });
-
-      const wrong = document.getElementsByClassName('wrong');
-      const correct = document.getElementsByClassName('correct')[0];
-
-      // ボタンが押されたら画面遷移
-      for (let i = 0; i < wrong.length; i++) {
-        wrong[i].addEventListener('click', () => {
-          const nextPageUrl = '../slide18/?from=slide27';
-
-          // 次のページを読み込む
-          window.fetch(nextPageUrl).then(() => {
-            // 読み込みが完了したら画面遷移を行う
-            window.location.href = nextPageUrl;
-          });
-        });
-      }
-
-      // ボタンが押されたら画面遷移
-      correct.addEventListener('click', () => {
-        const nextPageUrl = '../slide19/?from=slide27';
-
-        // 次のページを読み込む
+      // 流れるカードはクリック判定をコンテナ委譲で処理
+      container.addEventListener('click', (e) => {
+        const btn = e.target.closest('.textButton');
+        if (!btn) return;
+        const nextPageUrl = btn.classList.contains('correct')
+          ? '../slide19/?from=slide27'
+          : '../slide18/?from=slide27';
         window.fetch(nextPageUrl).then(() => {
-          // 読み込みが完了したら画面遷移を行う
           window.location.href = nextPageUrl;
         });
       });
 
+      // 無操作なら5秒で不正解ルートへ
       setTimeout(() => {
         const nextPageUrl = '../slide18/?from=slide27';
-
-        // 次のページを読み込む
         window.fetch(nextPageUrl).then(() => {
-          // 読み込みが完了したら画面遷移を行う
           window.location.href = nextPageUrl;
         });
       }, 5000);

--- a/src/pages/unusable_HI_Mansion/slides/slide29.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide29.astro
@@ -45,6 +45,11 @@ import ghost_teacher from './Images/_ghost_teacher.png';
     .marquee-track .textButton {
       flex-shrink: 0;
       margin-right: 3.5vw;
+      /* 4行に収めるためカードを縮小(このクイズ内だけにスコープ) */
+      width: max(70px, 7vw);
+      height: max(70px, 7vw);
+      font-size: max(34px, 3.4vw);
+      line-height: max(70px, 7vw);
     }
   </style>
   <div class="slide-content">

--- a/src/pages/unusable_HI_Mansion/slides/slide29.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide29.astro
@@ -19,8 +19,32 @@ import ghost_teacher from './Images/_ghost_teacher.png';
       background-color: #e73;
     }
 
+    .purple {
+      background-color: #9575cd;
+    }
+
     .brown {
       background-color: #831;
+    }
+
+    /* slide27 と同じく各行を回転寿司のように横スクロールさせる */
+    .marquee-row {
+      position: absolute;
+      left: 0;
+      width: 100%;
+      height: max(70px, 7vw);
+      overflow: hidden;
+    }
+    .marquee-track {
+      display: flex;
+      flex-wrap: nowrap;
+      width: max-content;
+      height: 100%;
+      will-change: transform;
+    }
+    .marquee-track .textButton {
+      flex-shrink: 0;
+      margin-right: 3.5vw;
     }
   </style>
   <div class="slide-content">
@@ -30,7 +54,7 @@ import ghost_teacher from './Images/_ghost_teacher.png';
     >
       <div
         class="text white"
-        style="position: absolute; display: inline-block; font-size: max(40px, 3.6vw); opacity: 0;"
+        style="position: absolute; display: inline-block; font-size: max(40px, 3.6vw); opacity: 0; z-index: 3;"
       >
         例えば、色分けすると<br />
         少しわかりやすくなりますね！
@@ -40,53 +64,132 @@ import ghost_teacher from './Images/_ghost_teacher.png';
       src={ghost_teacher}
       alt="ghost teacher"
       class="ghost"
-      style="width: max(180px, 14vw); opacity: 0; position: absolute; top: 18%; left: 10%;"
+      style="width: max(180px, 14vw); opacity: 0; position: absolute; top: 18%; left: 10%; z-index: 2;"
     />
     <div id="container" style="opacity: 0;"></div>
   </div>
   <script is:inline>
-    function createTextButton(text, index, className, color) {
+    // slide27 と同じ縦位置・向き・速度で流す(種明かしとして同一の盤面を再現)
+    const ROWS_META = [
+      { top: '33%', dir: 'left', speed: 110 },
+      { top: '48%', dir: 'right', speed: 95 },
+      { top: '63%', dir: 'left', speed: 130 },
+      { top: '78%', dir: 'right', speed: 105 }
+    ];
+    const ROW_SIZES = [13, 13, 13, 13];
+
+    const WRONG_POOL = [
+      { text: '太', class: 'wrong', color: 'blue' },
+      { text: '犬', class: 'wrong', color: 'green' },
+      { text: '人', class: 'wrong', color: 'purple' },
+      { text: '木', class: 'wrong', color: 'brown' }
+    ];
+
+    // localStorage が無い場合のフォールバック(単体表示・テスト用)
+    function buildRows() {
+      const total = ROW_SIZES.reduce((a, b) => a + b, 0);
+      const cards = [];
+      for (let i = 0; i < total; i++) {
+        const w = WRONG_POOL[Math.floor(Math.random() * WRONG_POOL.length)];
+        cards.push({ text: w.text, class: w.class, color: w.color });
+      }
+      const correctIndex = Math.floor(Math.random() * total);
+      cards[correctIndex] = { text: '大', class: 'correct', color: 'orange' };
+      const rows = [];
+      let offset = 0;
+      for (const size of ROW_SIZES) {
+        rows.push(cards.slice(offset, offset + size));
+        offset += size;
+      }
+      return rows;
+    }
+
+    function createCard(card) {
       const div = document.createElement('div');
-      div.textContent = text;
-      div.classList.add('textButton', className, color);
-      div.style.position = 'absolute';
-      div.style.top = getTop(index);
-      div.style.left = getLeft(index);
+      div.textContent = card.text;
+      div.classList.add('textButton', card.class, card.color);
       return div;
     }
 
-    function getTop(index) {
-      if (index < 7) {
-        return '40%';
-      }
-      if (index < 14) {
-        return '60%';
-      }
-      if (index < 21) {
-        return '80%';
-      }
-      return 0;
-    }
+    function renderRows(container, rows) {
+      rows.forEach((rowData, i) => {
+        const meta = ROWS_META[i];
+        const row = document.createElement('div');
+        row.className = 'marquee-row';
+        row.style.top = meta.top;
 
-    function getLeft(index) {
-      return `${(index % 7) * 12 + 10}%`;
+        const track = document.createElement('div');
+        track.className = 'marquee-track';
+
+        rowData.concat(rowData).forEach((card) => {
+          track.appendChild(createCard(card));
+        });
+
+        row.appendChild(track);
+        container.appendChild(row);
+
+        const first = track.children[0];
+        const second = track.children[rowData.length];
+        const dist = second.offsetLeft - first.offsetLeft; // 1周分の幅
+        const dur = (dist / meta.speed) * 1000;
+
+        // 種明かしでも「大」を含む行は読み込み直後に端の外へ隠し、すぐ現れさせる
+        let delay = 0;
+        const daiIndex = rowData.findIndex((c) => c.class === 'correct');
+        if (daiIndex !== -1) {
+          const W = row.clientWidth;
+          const daiOffset =
+            track.children[daiIndex].offsetLeft - first.offsetLeft;
+          // 左へ流れる行は右端の外、右へ流れる行は左端の外に隠す
+          const cardW = track.children[daiIndex].getBoundingClientRect().width;
+          const enterOffset = W * (0.02 + Math.random() * 0.12);
+          const x0 =
+            meta.dir === 'left' ? W + enterOffset : -cardW - enterOffset;
+          const desired =
+            ((((x0 - daiOffset) % dist) + dist) % dist) - dist; // [-dist, 0)
+          const ct =
+            meta.dir === 'left'
+              ? (-desired / dist) * dur
+              : dur * (1 + desired / dist);
+          delay = -ct;
+        }
+
+        const from = meta.dir === 'left' ? 0 : -dist;
+        const to = meta.dir === 'left' ? -dist : 0;
+        track.animate(
+          [
+            { transform: 'translateX(' + from + 'px)' },
+            { transform: 'translateX(' + to + 'px)' }
+          ],
+          {
+            duration: dur,
+            iterations: Infinity,
+            easing: 'linear',
+            delay: delay
+          }
+        );
+      });
     }
 
     window.addEventListener('DOMContentLoaded', function () {
-      const shuffledButtons = JSON.parse(
-        localStorage.getItem('shuffledButtons')
-      );
       const container = document.getElementById('container');
       const text = document.querySelector('.text');
       const ghost = document.querySelector('.ghost');
 
-      shuffledButtons.forEach((button, index) => {
-        const { text, class: className, color: color } = button;
-        const element = createTextButton(text, index, className, color);
-        container.appendChild(element);
-      });
+      let rows = null;
+      try {
+        rows = JSON.parse(localStorage.getItem('shuffledButtons'));
+      } catch (e) {
+        rows = null;
+      }
+      // 旧形式(フラット配列)や未設定なら生成し直す
+      if (!Array.isArray(rows) || !Array.isArray(rows[0])) {
+        rows = buildRows();
+      }
 
-      this.setTimeout(() => {
+      renderRows(container, rows);
+
+      setTimeout(() => {
         container.style.transition = 'opacity 2s ease-in-out';
         text.style.transition = 'opacity 2s ease-in-out';
         ghost.style.transition = 'opacity 2s ease-in-out';

--- a/src/pages/unusable_HI_Mansion/slides/slide3.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide3.astro
@@ -4,6 +4,7 @@ import SlideLayout from '@layouts/slide_layout.astro';
 
 <SlideLayout>
   <div class="slide-content">
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div
       class="textArea flex justify-center"
       style="margin-top: max(220px, 24vw);"
@@ -46,11 +47,25 @@ import SlideLayout from '@layouts/slide_layout.astro';
     window.addEventListener('DOMContentLoaded', () => {
       const textFirst = document.querySelector('.first');
       const buttonArea = document.querySelector('.buttonArea');
+      const seekFill = document.querySelector('.seek-fill');
 
       // 画面の要素を時間差で登場させる
       setTimeout(() => {
         textFirst.style.transition = 'opacity 2s ease-in-out';
         textFirst.style.opacity = 1;
+        // 文字表示開始と同時にシークバーを5秒でゼロにする(急かし演出)
+        const seekAnim = seekFill.animate(
+          [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+          { duration: 5000, easing: 'linear', fill: 'forwards' }
+        );
+        // 時間切れ(バーがゼロ)で YES が倒れて下に消え、NO しか押せなくなる
+        seekAnim.finished.then(() => {
+          const yesButton = document.getElementById('yes');
+          yesButton.style.transition = 'top 2s, transform 1s';
+          yesButton.style.transform = 'translate(-50%, -50%) rotateX(90deg)';
+          yesButton.style.top = '110%';
+          yesButton.style.pointerEvents = 'none';
+        });
       }, 1000);
 
       setTimeout(() => {

--- a/src/pages/unusable_HI_Mansion/slides/slide4.astro
+++ b/src/pages/unusable_HI_Mansion/slides/slide4.astro
@@ -6,10 +6,35 @@ import ghost from './Images/_ghost.png';
 ---
 
 <SlideLayout>
+  <style is:inline>
+    /* slide4 は色の一貫性も崩す罠: 緑=NO(左) / 赤=YES(右) と反転。
+       色味は他ボタンと同じ暗くぼやけたトーン(赤は既定、緑はその緑版) */
+    .slide-content #no {
+      color: #3a3;
+      background: linear-gradient(to bottom, #004d00, #003300);
+      box-shadow: 0 0 1vw rgba(0, 200, 0, 0.8);
+    }
+    .slide-content #no:hover {
+      color: #3f3;
+      background: linear-gradient(to bottom, #070, #040);
+      box-shadow: 0 0 2vw rgba(0, 200, 0, 0.8);
+    }
+    .slide-content #yes {
+      color: #a33;
+      background: linear-gradient(to bottom, #4d0000, #330000);
+      box-shadow: 0 0 1vw rgba(230, 0, 0, 0.8);
+    }
+    .slide-content #yes:hover {
+      color: #f33;
+      background: linear-gradient(to bottom, #700, #400);
+      box-shadow: 0 0 2vw rgba(230, 0, 0, 0.8);
+    }
+  </style>
   <div
     class="slide-content flex"
     style="align-items: center; position: relative;"
   >
+    <div class="seek-bar"><div class="seek-fill"></div></div>
     <div
       class="textArea flex justify-center"
       style="flex: 1; display: flex; justify-content: center; align-items: center;"
@@ -58,6 +83,21 @@ import ghost from './Images/_ghost.png';
     window.addEventListener('DOMContentLoaded', () => {
       const buttonArea = document.querySelector('.buttonArea');
       const ghost = document.querySelector('.ghost');
+      const seekFill = document.querySelector('.seek-fill');
+
+      // 文字は最初から表示されているので、読み込み直後にシークバー開始(5秒)
+      const seekAnim = seekFill.animate(
+        [{ transform: 'scaleX(1)' }, { transform: 'scaleX(0)' }],
+        { duration: 5000, easing: 'linear', fill: 'forwards' }
+      );
+      // 時間切れ(バーがゼロ)で YES が倒れて下に消え、NO しか押せなくなる
+      seekAnim.finished.then(() => {
+        const yesButton = document.getElementById('yes');
+        yesButton.style.transition = 'top 2s, transform 1s';
+        yesButton.style.transform = 'translate(-50%, -50%) rotateX(90deg)';
+        yesButton.style.top = '110%';
+        yesButton.style.pointerEvents = 'none';
+      });
 
       setTimeout(() => {
         buttonArea.style.transition = 'opacity 1s ease-in-out';


### PR DESCRIPTION
## 概要

「使いにくいヒューマンインターフェースの館」(`src/pages/unusable_HI_Mansion/`) の体験を改修しました。**方向クイズ（矢印）**・**大探しクイズ**・導入の **YES/NO スライド**に、色分け・急かし演出（シークバー）・ひっかけロジックの見直しを入れています。変更はすべて当該ディレクトリ配下のスライドのみで、他機能への影響はありません。ローカル & CI（`Build Website`）でビルド成功を確認済み（163ページ）。

## 変更点（機能・スライド別）

### 1. 共通スタイル `_style.css`
- `.imageText`（矢印上に重なる漢字）に `font-weight: bold` を追加。
- `#yes` / `#yes:hover` を新規追加（YES ボタン専用の暗い緑配色。NO は既定の赤ボタンのまま）。
- `.seek-bar` / `.seek-fill` を新規追加（**画面下部**の「残り時間」バー。太さ `max(24px, 2.2vw)`、赤系グラデーション。JS 側で `scaleX(1)→0` にアニメーション）。
- `.textButton` のサイズは**据え置き**（大クイズの縮小は各スライドにスコープ。後述）。

### 2. 導入 YES/NO スライド（slide2 / slide3 / slide4）
- 下部にシークバー（5秒）を追加。**時間切れで YES ボタンが倒れて消滅**（`transform: rotateX(90deg)` ＋ `top:110%` ＋ `pointer-events:none`）**→ NO しか押せなくなる**。
- slide2 / slide3: ボタン表示を早め（文字と被るタイミング）。slide2 はボタン表示 6s→2s、「それでも入りますか？」の行間 `10vw→5vw`。
- slide4: `<style is:inline>` で **色だけ左右反転**（NO=緑 / YES=赤。ボタン配置・ラベルは既存のまま＝「一貫性を崩す罠」）。文字が最初から出ているため、シークバーは読み込み直後に開始。

### 3. 方向クイズ 1・2問目（slide14 / slide15）
- 選択肢カードを**方向色の背景**（上=赤 / 右=緑 / 下=青 / 左=橙）＋漢字 Bold ＋**矢印の白枠除去**（`clip-path: inset(6%)`）。
- 問題文を**蛍光ペン**化（slide14=赤地 / slide15=青地、白文字）。
- 3秒の制限時間をシークバーで可視化。
- **正解位置を記録**（`arrowLastCorrectPos`）。slide15 は前問と同じ位置に正解が来ないよう再シャッフル。

### 4. 方向クイズ 3問目（slide16）— ひっかけロジック改修
- 問題文 蛍光ペン（橙地・白文字）。カード配色・白枠除去・Bold は 1・2問目と同様。
- **文字と色は固定ペア**（左=橙 など）、**矢印の向きだけをシャッフル**（どのカードも文字と一致しない derangement）。
- **「左」の文字は必ず右向き矢印に固定**（上下より左右の取り違えを誘発）。
- 正解＝**矢印が左を指すカード**、ひっかけ＝**文字が「左」/橙だが矢印は左でないカード**、残りは不正解。
- ひっかけ（`incorrect`）を**前問（2問目）の正解位置**に固定し、正解はそれ以外の位置に配置。
- 生成結果を `shuffledArrows` に保存（解説で同じ盤面を再現）。

### 5. 解説（slide20）
- `shuffledArrows` を**色付きで再現**（3問目と一致）、矢印の白枠除去。
- 下段の矢印群を**図形の 20% 分 上へ移動**（`translateY(-20%)`）。

### 6. 大探しクイズ（slide27）／種明かし（slide29）
- 固定グリッド配置 → **横スクロールの「回転寿司」**に全面刷新（各行の内容を2連結し実測幅でシームレスループ、Web Animations API）。
- **4行**（各行13枚＝合計52枚、「大」は全体で1枚）。行ごとに流れる向き・速度を変化。
- カードを縮小（`.marquee-track .textButton` で `7vw` に**このクイズ内だけスコープ**。共有 `.textButton` を使う slide25 等には非波及）。
- **「大」の出現保証**：大を含む行は読み込み直後に進行方向の画面外へ隠し、制限時間内に必ず流れて現れるよう位相（負の delay）を逆算。
- 動的生成に伴い、クリック判定をコンテナへの**イベント委譲**に変更。
- slide27: 5秒シークバー追加（既存の「5秒無操作で slide18 へ」ロジックは維持）。
- slide29: 色分け（太=青 / 犬=緑 / 人=紫 / 木=茶 / 大=橙、`.purple` 追加）、localStorage 未設定時のフォールバック生成、テキスト/ゴーストの z-index 調整。

## レビュー観点・注意点
- 変更はすべて `src/pages/unusable_HI_Mansion/` 配下のみ。他ページ・他機能への影響なし。
- ローカル & CI でビルド成功（163ページ / Complete）。
- 既存の無関係なビルド警告（`content/blog/events/2024/June-monthly-blog` のパース）はこの PR と無関係で、ビルド自体は成功します。
- slide12（例示）は最終的に変更なし（作業途中の変更を元に戻したため diff に含まれません）。
- **このブランチ（main）を `production` にマージすると `Deploy Website to AWS`（S3 sync ＋ CloudFront `/*` 無効化）が走り、本番反映されます。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
